### PR TITLE
25 register frontend(ACHTUNG! ZUERST #74 MERGEN)

### DIFF
--- a/src/app/features/auth/register/register.css
+++ b/src/app/features/auth/register/register.css
@@ -1,0 +1,27 @@
+h1 {
+    text-align: center;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    gap: 16px;
+}
+.error {
+    color: #b00020;
+    font-size: 12px;
+    margin-top: -16px;
+    padding-left: 16px;
+}
+
+.register-wrapper{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: calc(100vh - 60px);
+}
+mat-card-header{
+margin-bottom: 16px
+
+}

--- a/src/app/features/auth/register/register.html
+++ b/src/app/features/auth/register/register.html
@@ -1,1 +1,65 @@
-<h1>Register - coming soon!</h1>
+<div class="register-wrapper">
+    <mat-card>
+
+        <mat-card-header>Register</mat-card-header>
+        <mat-card-content>
+            <form [formGroup]="form" (ngSubmit)="onSubmit()">
+
+                <div>
+                    <mat-form-field appearance="outline">
+                        <mat-label>E-Mail</mat-label>
+                        <input matInput type="email" formControlName="email" />
+                        @if (form.get('email')?.hasError('required')) {
+                        <mat-error>Email is required</mat-error>
+                        }
+                        @if (form.get('email')?.hasError('email')) {
+                        <mat-error>Invalid email format</mat-error>
+                        }
+
+                         @if (form.get('email')?.hasError('pattern')) {
+                        <mat-error>Please enter a valid email address (e.g. name@example.com)</mat-error>
+                        }
+                    </mat-form-field>
+                </div>
+
+                <div>
+                    <mat-form-field appearance="outline">
+                        <mat-label>Password</mat-label>
+                        <input matInput type="password" formControlName="password" />
+
+                        @if (form.get('password')?.hasError('required')) {
+                        <mat-error>Password is required</mat-error>
+                        }
+
+                        @if (form.get('password')?.hasError('minlength')) {
+                        <mat-error>Password must be at least 8 characters</mat-error>
+                        }
+                       
+                    </mat-form-field>
+                </div>
+
+                <div>
+                    <mat-form-field appearance="outline">
+                        <mat-label>Confirm your Password</mat-label>
+                        <input matInput type="password" formControlName="confirmPassword" />
+                    </mat-form-field>
+
+                    @if (form.hasError('passwordMismatch') && form.get('confirmPassword')?.touched) {
+                    <p class="error">Passwords do not match</p>
+                    }
+                </div>
+
+                @if (errorMessage) {
+                <p class="error">{{ errorMessage }}</p>
+                }
+
+                <button type="submit" mat-raised-button color="primary" [disabled]="form.invalid">
+                    Register
+                </button>
+
+
+            </form>
+
+        </mat-card-content>
+    </mat-card>
+</div>

--- a/src/app/features/auth/register/register.html
+++ b/src/app/features/auth/register/register.html
@@ -1,1 +1,61 @@
-<h1>Register - coming soon!</h1>
+<div class="register-wrapper">
+    <mat-card>
+
+        <mat-card-header>Register</mat-card-header>
+        <mat-card-content>
+            <form [formGroup]="form" (ngSubmit)="onSubmit()">
+
+                <div>
+                    <mat-form-field appearance="outline">
+                        <mat-label>E-Mail</mat-label>
+                        <input matInput type="email" formControlName="email" />
+                        @if (form.get('email')?.hasError('required')) {
+                        <mat-error>Email is required</mat-error>
+                        }
+                        @if (form.get('email')?.hasError('email')) {
+                        <mat-error>Invalid email format</mat-error>
+                        }
+
+                         @if (form.get('email')?.hasError('pattern')) {
+                        <mat-error>Please enter a valid email address (e.g. name@example.com)</mat-error>
+                        }
+                    </mat-form-field>
+                </div>
+
+                <div>
+                    <mat-form-field appearance="outline">
+                        <mat-label>Password</mat-label>
+                        <input matInput type="password" formControlName="password" />
+
+                        @if (form.get('password')?.hasError('required')) {
+                        <mat-error>Password is required</mat-error>
+                        }
+
+                        @if (form.get('password')?.hasError('minlength')) {
+                        <mat-error>Password must be at least 8 characters</mat-error>
+                        }
+                       
+                    </mat-form-field>
+                </div>
+
+                <div>
+                    <mat-form-field appearance="outline">
+                        <mat-label>Confirm your Password</mat-label>
+                        <input matInput type="password" formControlName="confirmPassword" />
+                    </mat-form-field>
+
+                    @if (form.hasError('passwordMismatch') && form.get('confirmPassword')?.touched) {
+                    <p class="error">Passwords do not match</p>
+                    }
+                </div>
+
+                <button type="submit" mat-raised-button color="primary" [disabled]="form.invalid">
+                    Register
+                </button>
+
+
+            </form>
+
+        </mat-card-content>
+    </mat-card>
+</div>

--- a/src/app/features/auth/register/register.ts
+++ b/src/app/features/auth/register/register.ts
@@ -1,9 +1,63 @@
 import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { AuthService } from '../../../shared/services/auth.service';
+import { MatCardModule } from '@angular/material/card';
+import { AbstractControl } from '@angular/forms';
+import { Router } from '@angular/router'
+
+
+
+function passwordMatchValidator(form: AbstractControl) {
+  const password = form.get('password')?.value;
+  const confirm = form.get('confirmPassword')?.value;
+  return password === confirm ? null : { passwordMismatch: true };
+}
 
 @Component({
   selector: 'app-register',
-  imports: [],
+  imports: [ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatCardModule
+  ],
   templateUrl: './register.html',
   styleUrl: './register.css',
 })
-export class Register {}
+export class Register {
+
+  constructor(private authService: AuthService, private router: Router) { }
+
+  errorMessage = '';
+
+  form = new FormGroup({
+    email: new FormControl('', [
+      Validators.required,
+      Validators.email,
+      Validators.pattern(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/)
+    ]),
+    password: new FormControl('', [Validators.required, Validators.minLength(8)]),
+    confirmPassword: new FormControl('', [Validators.required]),
+  }, { validators: passwordMatchValidator });
+
+  onSubmit() {
+    const { email, password } = this.form.value;
+    this.authService.register(email!, password!)
+      .then(() => this.router.navigate(['/']))
+      .catch((error) => {
+        if (error.code === 'auth/email-already-in-use') {
+          this.errorMessage = 'Email is already in use';
+        } else if (error.code === 'auth/weak-password') {
+          this.errorMessage = 'Password is too weak';
+        } else {
+          this.errorMessage = 'Something went wrong. Please try again';
+        }
+      });
+
+  }
+}
+
+

--- a/src/app/features/auth/register/register.ts
+++ b/src/app/features/auth/register/register.ts
@@ -1,9 +1,48 @@
 import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { AuthService } from '../../../shared/services/auth.service';
+import { MatCardModule } from '@angular/material/card';
+import { AbstractControl } from '@angular/forms';
+
+
+
+
+function passwordMatchValidator(form: AbstractControl) {
+  const password = form.get('password')?.value;
+  const confirm = form.get('confirmPassword')?.value;
+  return password === confirm ? null : { passwordMismatch: true };
+}
 
 @Component({
   selector: 'app-register',
-  imports: [],
+  imports: [ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatCardModule
+  ],
   templateUrl: './register.html',
   styleUrl: './register.css',
 })
-export class Register {}
+export class Register {
+
+  form = new FormGroup({
+    email: new FormControl('', [
+      Validators.required,
+      Validators.email,
+      Validators.pattern(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/)
+    ]),
+    password: new FormControl('', [Validators.required, Validators.minLength(8)]),
+    confirmPassword: new FormControl('', [Validators.required]),
+  }, { validators: passwordMatchValidator });
+
+  onSubmit() {
+    console.log(this.form.value);
+    this.form.reset()
+  }
+}
+
+


### PR DESCRIPTION
closes #25, closes #26 
## Changes from 0be76fb
- add register form (email, password and confirm password)
- email must have a valid format and a real domain (e.g. name@example.com)
- password must be at least 8 characters
- added  validator that checks if both passwords match
- error messages shown below each field using mat-error
- register button is disabled when form is not valid
- on submit: logs form values to console and resets the form
- added register-wrapper CSS class for card centering
> no Firebase connection yet — will be added in a later issue.   #26   