### PR TITLE
Auth-Guard 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ __screenshots__/
 
 .DS_Store
 src/environments/environment.ts
+src/environments/environment.prod.ts

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,13 +6,14 @@ import { Profile } from './features/profile/profile';
 import { Commands } from './features/commands/commands';
 import { Intro } from './features/intro/intro';
 import { NotFound } from './not-found/not-found';
+import { authGuard } from './shared/guards/auth.guard'; 
 
 export const routes: Routes = [
-    { path: "", component: GameComponent },
+    { path: "", component: GameComponent, canActivate: [authGuard] },
     { path: "login", component: Login },
     { path: "register", component: Register },
-    { path: "profile", component: Profile },
-    { path: "commands", component: Commands },
+    { path: "profile", component: Profile, canActivate:[authGuard] },
+    { path: "commands", component: Commands, canActivate: [authGuard] },
     { path: "intro", component: Intro },
     { path: "**", component: NotFound }
 

--- a/src/app/shared/guards/auth.guard.spec.ts
+++ b/src/app/shared/guards/auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) =>
+    TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/shared/guards/auth.guard.ts
+++ b/src/app/shared/guards/auth.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+import { environment } from '../../../environments/environment';
+
+export const authGuard: CanActivateFn = () => {
+  if (environment.skipAuthGuard) return true;
+
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  return new Promise((resolve) => {
+    authService.onAuthChange((user) => {
+      if (user) {
+        resolve(true);
+      } else {
+        router.navigate(['/login']);
+        resolve(false);
+      }
+    });
+  });
+};


### PR DESCRIPTION
closes #30 

## Änderungen 
---
**Neu:**
-`src/app/shared/guards/auth-guard.ts`
> Es ist ein Angular Guard der vor dem Laden einer Rote prüft ob ein Firebase user eingeloggt ist. 
falls ja--> Route erlauben, falls nein--> zu `/login`. zurück

>⚠️ Für die Entwicklung brauchen wir in *environment.ts* ein skipAuthGuard-Flag, der den Guard komplett überspringt 

- src/environments/environment.prod.ts
> Das ist für die Produktion, sie ist gleich wie die environment.ts  nur dass hier `skipAuthGuard: false` immer auf false ist. 
----
 **Geändert:**
- `src/app/app.routes.ts`
>  Routen `/`, `/profile` und `/commands` wurden mit canActivate : [authGuard] geschützt 

- `src/environments/environment.ts`
> nach dieser Zeile:   production: false das hier hinzugefügt -->skipAuthGuard: true,
Diese Änderung wird in dem commit nicht erschienen, weil die Datei in .gitignore ist. 

